### PR TITLE
Don't expose data from operator credentials, already exposed

### DIFF
--- a/service/collector/rate_limit.go
+++ b/service/collector/rate_limit.go
@@ -111,14 +111,6 @@ func (u *RateLimit) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	// The operator potentially uses a different set of credentials than
-	// tenant clusters, so we add the operator credentials as well.
-	operatorClientSet, err := client.NewAzureClientSet(u.cpAzureClientSetConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	clientSets[&u.cpAzureClientSetConfig] = operatorClientSet
-
 	ctx := context.Background()
 
 	// We track RateLimit metrics for each client labeled by SubscriptionID and

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -76,14 +76,6 @@ func (r *ResourceGroup) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	// The operator potentially uses a different set of credentials than
-	// tenant clusters, so we add the operator credentials as well.
-	operatorClientSet, err := client.NewAzureClientSet(r.cpAzureClientSetConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	clientSets[r.cpAzureClientSetConfig.SubscriptionID] = operatorClientSet
-
 	var g errgroup.Group
 
 	for _, item := range clientSets {

--- a/service/collector/usage.go
+++ b/service/collector/usage.go
@@ -97,14 +97,6 @@ func (u *Usage) Collect(ch chan<- prometheus.Metric) error {
 		return microerror.Mask(err)
 	}
 
-	// The operator potentially uses a different set of credentials than
-	// tenant clusters, so we add the operator credentials as well.
-	operatorClientSet, err := client.NewAzureClientSet(u.cpAzureClientSetConfig)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	clientSets[u.cpAzureClientSetConfig.SubscriptionID] = operatorClientSet
-
 	// We track usage metrics for each client labeled by subscription.
 	// That way we prevent duplicated metrics.
 	for subscriptionID, azureClientSet := range clientSets {


### PR DESCRIPTION
collector is complaining about metrics already exposed. I believe it's because the operator credentials are the same as the `credential-default` secret.