### PR TITLE
Fix vmss rate limit

### DIFF
--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -154,16 +154,10 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
 
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Response: %v", result.Response().Response.Response))
-
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
-
 				if len(headers) == 0 {
 					headers = result.Response().Response.Header[vmssVMListHeaderName]
 					doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
 				}
-
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("2) number of headers: %d", len(headers)))
 
 				// Header not found, we consider this an error.
 				if len(headers) == 0 {
@@ -172,7 +166,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				for _, l := range headers {
-					u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Considering header: %s", l))
 					// Limits are a single comma separated string.
 					tokens := strings.SplitN(l, ",", -1)
 					for _, t := range tokens {

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -143,8 +143,9 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				var headers []string
 
 				// Calling the VMSS list machines API to get the metrics.
-				result, err := azureClients.VirtualMachineScaleSetVMsClient.ListComplete(ctx, cr.Name, fmt.Sprintf("%s-worker", cr.Name), "", "", "")
+				result, err := azureClients.VirtualMachineScaleSetVMsClient.ListComplete(ctx, cr.Name, fmt.Sprintf("%s-master-%s", cr.Name, cr.Name), "", "", "")
 				if err != nil {
+					u.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("Error calling azure API: %s", err))
 					detailed, ok := err.(autorest.DetailedError)
 					if !ok {
 						u.logger.LogCtx(ctx, fmt.Sprintf("Error listing VM instances on %s: %s", cr.Name, err.Error()))
@@ -153,6 +154,8 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					err = nil
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
+
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Response: %v", result.Response().Response.Response))
 
 				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
 

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -131,7 +131,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 			if inArray(doneSubscriptions, config.SubscriptionID) {
 				continue
 			}
-			doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
 
 			azureClients, err := client.NewAzureClientSet(*config)
 			if err != nil {
@@ -161,6 +160,7 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 
 				if len(headers) == 0 {
 					headers = result.Response().Response.Header[vmssVMListHeaderName]
+					doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
 				}
 
 				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("2) number of headers: %d", len(headers)))

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -154,9 +154,13 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
 
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
+
 				if len(headers) == 0 {
 					headers = result.Response().Response.Header[vmssVMListHeaderName]
 				}
+
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("2) number of headers: %d", len(headers)))
 
 				// Header not found, we consider this an error.
 				if len(headers) == 0 {
@@ -165,6 +169,7 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				for _, l := range headers {
+					u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Considering header: %s", l))
 					// Limits are a single comma separated string.
 					tokens := strings.SplitN(l, ",", -1)
 					for _, t := range tokens {


### PR DESCRIPTION
The VMSS rate limit collector wasn't updated after we changed the VMSS names back with the flatcar release.
This PR fixes this problem and makes the collection a little bit more reliable by marking a subscription as collected only if the API request towards azure returns the needed data.