### PR TITLE
Current vmss api calls

### DIFF
--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -154,16 +154,10 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
 
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Response: %v", result.Response().Response.Response))
-
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
-
 				if len(headers) == 0 {
 					headers = result.Response().Response.Header[vmssVMListHeaderName]
 					doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
 				}
-
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("2) number of headers: %d", len(headers)))
 
 				// Header not found, we consider this an error.
 				if len(headers) == 0 {
@@ -172,7 +166,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				for _, l := range headers {
-					u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Considering header: %s", l))
 					// Limits are a single comma separated string.
 					tokens := strings.SplitN(l, ",", -1)
 					for _, t := range tokens {

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -188,18 +188,18 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				for _, l := range headers {
-					// Limits are errorbody single comma separated string.
+					// Limits are a single comma separated string.
 					tokens := strings.SplitN(l, ",", -1)
 					for _, t := range tokens {
-						// Each limit's name and value are separated by errorbody semicolon.
+						// Each limit's name and value are separated by a semicolon.
 						kv := strings.SplitN(t, ";", 2)
 						if len(kv) != 2 {
-							// We expect exactly two tokens, otherwise we consider this errorbody parsing error.
+							// We expect exactly two tokens, otherwise we consider this a parsing error.
 							vmssVMListErrorCounter.Inc()
 							continue
 						}
 
-						// The second token must be errorbody number or we don't know what we got from MS.
+						// The second token must be a number or we don't know what we got from MS.
 						val, err := strconv.ParseFloat(kv[1], 64)
 						if err != nil {
 							vmssVMListErrorCounter.Inc()

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -154,10 +154,14 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
 
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
+
 				if len(headers) == 0 {
 					headers = result.Response().Response.Header[vmssVMListHeaderName]
 					doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
 				}
+
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("2) number of headers: %d", len(headers)))
 
 				// Header not found, we consider this an error.
 				if len(headers) == 0 {
@@ -166,6 +170,7 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				}
 
 				for _, l := range headers {
+					u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Considering header: %s", l))
 					// Limits are a single comma separated string.
 					tokens := strings.SplitN(l, ",", -1)
 					for _, t := range tokens {

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -154,6 +154,8 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 					headers = detailed.Response.Header[vmssVMListHeaderName]
 				}
 
+				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Response: %v", result.Response().Response.Response))
+
 				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("1) number of headers: %d", len(headers)))
 
 				if len(headers) == 0 {


### PR DESCRIPTION
This PR adds a new metric about the VMSS api rate limit (aka 429).
When a 429 is ongoing, azure sends back in the body of the HTTP response the details about the number of calls being made.
This helps understanding if the situation is improving or not.
