### PR TITLE
Check for double scrape of the same subscription in the rate limit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Check for double scrape of the same subscription in the rate limit collector.
+
 ## [2.0.0] - 2020-10-06
 
 ### Changed


### PR DESCRIPTION
the rate limit collector can scrape the same subscription twice and make the exporter to fail with a 500.

This PR addresses this problem