### PR TITLE
Add new collector to expose 'Cluster' CR conditions as metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new collector to expose `Cluster` CR conditions as metrics to be used as inhibitions.
+
 ## [2.2.0] - 2020-11-05
 
 ### Added

--- a/service/collector/conditions.go
+++ b/service/collector/conditions.go
@@ -1,0 +1,107 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ConditionsConfig struct {
+	CtrlClient ctrlclient.Client
+	Logger     micrologger.Logger
+}
+
+type Conditions struct {
+	ctrlClient ctrlclient.Client
+	logger     micrologger.Logger
+}
+
+var (
+	clusterStatus = prometheus.NewDesc(
+		prometheus.BuildFQName(MetricsNamespace, "cluster", "status"),
+		"Latest cluster status conditions as provided by the Cluster CR status.",
+		[]string{
+			"cluster_id",
+			"release_version",
+			"status",
+		},
+		nil,
+	)
+)
+
+func NewConditions(config ConditionsConfig) (*Conditions, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	u := &Conditions{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return u, nil
+}
+
+func (u *Conditions) Collect(ch chan<- prometheus.Metric) error {
+	ctx := context.Background()
+	clusters := &capiv1alpha3.ClusterList{}
+	{
+		err := u.ctrlClient.List(ctx, clusters, ctrlclient.InNamespace(metav1.NamespaceAll))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	for _, cluster := range clusters.Items {
+		releaseVersion, ok := cluster.Labels[label.ReleaseVersion]
+		if !ok {
+			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion))
+			continue
+		}
+
+		var isCreating float64
+		if conditions.IsTrue(&cluster, aeconditions.CreatingCondition) {
+			isCreating = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			clusterStatus,
+			prometheus.GaugeValue,
+			isCreating,
+			cluster.Name,
+			releaseVersion,
+			string(aeconditions.CreatingCondition),
+		)
+
+		var isUpgrading float64
+		if conditions.IsTrue(&cluster, aeconditions.UpgradingCondition) {
+			isUpgrading = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			clusterStatus,
+			prometheus.GaugeValue,
+			isUpgrading,
+			cluster.Name,
+			releaseVersion,
+			string(aeconditions.UpgradingCondition),
+		)
+	}
+
+	return nil
+}
+
+func (u *Conditions) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- clusterStatus
+	return nil
+}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -137,6 +137,7 @@ func NewSet(config SetConfig) (*Set, error) {
 			CtrlClient: config.K8sClient.CtrlClient(),
 			Logger:     config.Logger,
 		}
+
 		conditionsCollector, err = NewConditions(c)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -131,6 +131,18 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var conditionsCollector *Conditions
+	{
+		c := ConditionsConfig{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+		conditionsCollector, err = NewConditions(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var vpnConnectionCollector *VPNConnection
 	{
 		c := VPNConnectionConfig{
@@ -152,11 +164,12 @@ func NewSet(config SetConfig) (*Set, error) {
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				clusterTransitionTime,
+				conditionsCollector,
 				deploymentCollector,
 				resourceGroupCollector,
-				usageCollector,
 				rateLimitCollector,
 				spExpirationCollector,
+				usageCollector,
 				vmssRateLimitCollector,
 				vpnConnectionCollector,
 			},

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
We want to use inhibitions so that we don't get alerts when certain conditions are met, i.e get alerts while the cluster is still being created or while it's upgrading.

We are still missing the `ClusterDeleting` condition, but I don't think that's implemented yet.