### PR TITLE
Refresh logging to use new shorthands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.2.1
 	github.com/giantswarm/microkit v0.2.2
-	github.com/giantswarm/micrologger v0.3.4
+	github.com/giantswarm/micrologger v0.4.0
 	github.com/giantswarm/operatorkit/v2 v2.0.2
 	github.com/giantswarm/statusresource/v2 v2.0.0
 	github.com/giantswarm/versionbundle v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/giantswarm/microkit v0.2.2 h1:BNK55FyS+AXls6mH+81Iloo3z2+FRWqeEz2jYb7
 github.com/giantswarm/microkit v0.2.2/go.mod h1:XCj0vA/+jHiM03XDMlcWuvYdgZQyNS3O7ZVHDOUCYA8=
 github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2P7pZ7+6dBShMQs=
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
-github.com/giantswarm/micrologger v0.3.4 h1:NKD6pz1++Hkq/ulOT9iu7hwTnG3ZfjnPUtuK/tbeCc8=
-github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
+github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
+github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/giantswarm/operatorkit/v2 v2.0.0/go.mod h1:hPkK01XN+c6mk65Ox3M4TFLSX7SpySFnkVCn+uUeNrw=
 github.com/giantswarm/operatorkit/v2 v2.0.2 h1:S2O5lZBT1yeGFfR+/so5TSIXgbgCSrVceM3EccNmoGE=
 github.com/giantswarm/operatorkit/v2 v2.0.2/go.mod h1:Bl8gK7hYhvRQP0Ds26rwYdoSXbbr+NKRZmWtwqI7HFI=

--- a/service/collector/cluster_transition.go
+++ b/service/collector/cluster_transition.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/label"
 	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
@@ -66,12 +65,12 @@ func (u *ClusterTransitionTime) Collect(ch chan<- prometheus.Metric) error {
 	for _, cluster := range clusters.Items {
 		releaseVersion, ok := cluster.Labels[label.ReleaseVersion]
 		if !ok {
-			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion))
+			u.logger.Debugf(ctx, "Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion)
 			continue
 		}
 
 		if !conditions.IsFalse(&cluster, aeconditions.CreatingCondition) {
-			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Cluster %#q has no %#q condition or it's still being created. Skipping", cluster.Name, aeconditions.CreatingCondition))
+			u.logger.Debugf(ctx, "Cluster %#q has no %#q condition or it's still being created. Skipping", cluster.Name, aeconditions.CreatingCondition)
 			continue
 		}
 

--- a/service/collector/conditions.go
+++ b/service/collector/conditions.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/label"
 	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
@@ -67,7 +66,7 @@ func (u *Conditions) Collect(ch chan<- prometheus.Metric) error {
 	for _, cluster := range clusters.Items {
 		releaseVersion, ok := cluster.Labels[label.ReleaseVersion]
 		if !ok {
-			u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion))
+			u.logger.Debugf(ctx, "Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion)
 			continue
 		}
 

--- a/service/collector/rate_limit.go
+++ b/service/collector/rate_limit.go
@@ -140,13 +140,13 @@ func (u *RateLimit) Collect(ch chan<- prometheus.Metric) error {
 			}
 			resourceGroup, err := clientSet.GroupsClient.CreateOrUpdate(ctx, u.getResourceGroupName(), resourceGroup)
 			if err != nil {
-				u.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clientid %#q gstenantid %#q tenantid %#q", clientConfig.ClientID, clientConfig.GSTenantID, clientConfig.TenantID))
+				u.logger.Debugf(ctx, "clientid %#q gstenantid %#q tenantid %#q", clientConfig.ClientID, clientConfig.GSTenantID, clientConfig.TenantID)
 				return microerror.Mask(err)
 			}
 
 			writes, err = strconv.ParseFloat(resourceGroup.Response.Header.Get(remainingWritesHeaderName), 64)
 			if err != nil {
-				u.logger.Log("level", "warning", "message", "an error occurred parsing to float the value inside the rate limiting header for write requests", "stack", microerror.JSON(microerror.Mask(err)))
+				u.logger.Errorf(ctx, err, "an error occurred parsing to float the value inside the rate limiting header for write requests")
 				writes = 0
 				writesErrorCounter.Inc()
 			}
@@ -172,7 +172,7 @@ func (u *RateLimit) Collect(ch chan<- prometheus.Metric) error {
 
 			reads, err = strconv.ParseFloat(groupResponse.Response.Header.Get(remainingReadsHeaderName), 64)
 			if err != nil {
-				u.logger.Log("level", "warning", "message", "an error occurred parsing to float the value inside the rate limiting header for read requests", "stack", microerror.JSON(microerror.Mask(err)))
+				u.logger.Errorf(ctx, err, "an error occurred parsing to float the value inside the rate limiting header for read requests")
 				reads = 0
 				readsErrorCounter.Inc()
 			}

--- a/service/collector/sp_expiration.go
+++ b/service/collector/sp_expiration.go
@@ -92,7 +92,7 @@ func (v *SPExpiration) Collect(ch chan<- prometheus.Metric) error {
 	}
 
 	if len(azureClientSets) < 1 {
-		v.logger.LogCtx(ctx, "level", "debug", "message", "No clusters, skipping SP expiration collector")
+		v.logger.Debugf(ctx, "No clusters, skipping SP expiration collector")
 		return nil
 	}
 

--- a/service/collector/usage.go
+++ b/service/collector/usage.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -106,7 +105,7 @@ func (u *Usage) Collect(ch chan<- prometheus.Metric) error {
 	for subscriptionID, azureClientSet := range clientSets {
 		r, err := azureClientSet.UsageClient.List(ctx, u.location)
 		if err != nil {
-			u.logger.Log("level", "warning", "message", "an error occurred during the scraping of current compute resource usage information", "stack", fmt.Sprintf("%v", err))
+			u.logger.Errorf(ctx, err, "an error occurred during the scraping of current compute resource usage information")
 			u.usageScrapeError.Inc()
 		} else {
 			for r.NotDone() {


### PR DESCRIPTION
There are few `LogCtx()` calls in `warning` level due to additional key-value pairs so I left them as-is as I was thinking that those additional bits of information are mostly needed.

Otherwise this is just straight search & replace to use new functions.