### PR TITLE
Add specific metric for release recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `azure_operator_cluster_release` metric.
+
 ## [2.3.0] - 2020-12-11
 
 ### Added

--- a/service/collector/cluster/releases.go
+++ b/service/collector/cluster/releases.go
@@ -1,0 +1,68 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Releases struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+var (
+	clusterRelease = prometheus.NewDesc(
+		prometheus.BuildFQName(MetricsNamespace, "cluster", "release"),
+		"Cluster release version.",
+		[]string{
+			"cluster_id",
+			"release_version",
+		},
+		nil,
+	)
+)
+
+func NewReleases(ctrlClient client.Client, logger micrologger.Logger) (*Releases, error) {
+	if ctrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "ctrlClient must not be empty")
+	}
+	if logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
+	}
+
+	c := &Releases{
+		ctrlClient: ctrlClient,
+		logger:     logger,
+	}
+
+	return c, nil
+}
+
+func (c *Releases) Collect(ctx context.Context, cluster *capiv1alpha3.Cluster, ch chan<- prometheus.Metric) error {
+	releaseVersion, ok := cluster.Labels[label.ReleaseVersion]
+	if !ok {
+		c.logger.Debugf(ctx, "Cluster %#q has no %#q label. Skipping", cluster.Name, label.ReleaseVersion)
+		return nil
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		clusterRelease,
+		prometheus.GaugeValue,
+		1,
+		cluster.Name,
+		releaseVersion,
+	)
+
+	return nil
+}
+
+func (c *Releases) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- clusterRelease
+	return nil
+}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -43,12 +43,18 @@ func NewSet(config SetConfig) (*Set, error) {
 			return nil, microerror.Mask(err)
 		}
 
+		releases, err := cluster.NewReleases(config.K8sClient.CtrlClient(), config.Logger)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		transition, err := cluster.NewTransitionTime(config.K8sClient.CtrlClient(), config.Logger)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
 		clusterCollectors.Add(conditions)
+		clusterCollectors.Add(releases)
 		clusterCollectors.Add(transition)
 	}
 


### PR DESCRIPTION
To have metric value of `1` for each cluster, accompanied with label for
current release version, add a specific metric for this.

Earlier use of `azure_operator_cluster_status` metric requires
unnecessarily hacky query to function correctly for release statistics
purposes so it's better to have a specific metric for this.