### PR TITLE
Remove hardcoded container registry

### DIFF
--- a/helm/azure-collector/values.yaml
+++ b/helm/azure-collector/values.yaml
@@ -4,10 +4,6 @@ project:
 image:
   name: "giantswarm/azure-collector"
   tag: "[[ .Version ]]"
-Installation:
-  V1:
-    Registry:
-      Domain: quay.io
 pod:
   user:
     id: 1000


### PR DESCRIPTION
Container registry for images should be defined in `installations`,
either by defaulting or with an override per installation.