### PR TITLE
Removed usage of deprecated flag `SPTenantID`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Always use `tenant ID` and ignore `GS tenant ID` flag.
+
 ## [2.4.0] - 2020-12-16
 
 ### Added

--- a/flag/service/azure/azure.go
+++ b/flag/service/azure/azure.go
@@ -6,5 +6,4 @@ type Azure struct {
 	PartnerID      string
 	SubscriptionID string
 	TenantID       string
-	SPTenantID     string
 }

--- a/main.go
+++ b/main.go
@@ -118,7 +118,6 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Azure.PartnerID, "", "Partner id used in Azure for the attribution partner program.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.SubscriptionID, "", "ID of the Azure Subscription.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.TenantID, "", "ID of the Active Directory Tenant.")
-	daemonCommand.PersistentFlags().String(f.Service.Azure.SPTenantID, "", "ID of the Active Directory Tenant ID used for authentication.")
 	daemonCommand.PersistentFlags().String(f.Service.ControlPlaneResourceGroup, "", "Control plane resource group name.")
 	daemonCommand.PersistentFlags().String(f.Service.Location, "westeurope", "Azure location of the host and guset clusters.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")

--- a/service/service.go
+++ b/service/service.go
@@ -126,7 +126,7 @@ func New(config Config) (*Service, error) {
 			Location:                  config.Viper.GetString(config.Flag.Service.Location),
 			Logger:                    config.Logger,
 			K8sClient:                 k8sClient,
-			GSTenantID:                config.Viper.GetString(config.Flag.Service.Azure.SPTenantID),
+			GSTenantID:                config.Viper.GetString(config.Flag.Service.Azure.TenantID),
 		}
 
 		operatorCollector, err = collector.NewSet(c)


### PR DESCRIPTION
Removed the deprecated field `SPTenantID` and used `TenantID` instead.