### PR TITLE
Avoid scraping service principal expiration on customer installations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid scraping service principal expiration on customer installations.
+
 ## [2.5.0] - 2021-06-22
 
 ### Changed


### PR DESCRIPTION
now that service principals are all in the `GS` tenant, scraping the expiration dates in the customer tenants doesn't make any sense and it will always fail.

This PR disables that exporter for installations not using the GS tenant id.