### PR TITLE
Add exporter with number of instances backing Load Balancers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add exporter with number of instances backing Load Balancers.
+
 ## [2.7.1] - 2021-08-27
 
 ### Fixed

--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -35,6 +35,8 @@ type AzureClientSet struct {
 	DeploymentsClient *resources.DeploymentsClient
 	// GroupsClient manages ARM resource groups.
 	GroupsClient *resources.GroupsClient
+	// LoadBalancersClient manages Load Balancer resources.
+	LoadBalancersClient *network.LoadBalancersClient
 	// UsageClient is used to work with limits and quotas.
 	UsageClient *compute.UsageClient
 	// VirtualNetworkGatewayConnectionsClient manages virtual network gateway connections.
@@ -83,6 +85,10 @@ func NewAzureClientSet(config AzureClientSetConfig) (*AzureClientSet, error) {
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	loadBalancersClient, err := newLoadBalancersClient(config.Authorizer, config.SubscriptionID, config.PartnerID)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	usageClient, err := newUsageClient(config.Authorizer, config.SubscriptionID, config.PartnerID)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -100,6 +106,7 @@ func NewAzureClientSet(config AzureClientSetConfig) (*AzureClientSet, error) {
 		ApplicationsClient:                     applicationsClient,
 		DeploymentsClient:                      deploymentsClient,
 		GroupsClient:                           groupsClient,
+		LoadBalancersClient:                    loadBalancersClient,
 		UsageClient:                            usageClient,
 		VirtualNetworkGatewayConnectionsClient: virtualNetworkGatewayConnectionsClient,
 		VirtualMachineScaleSetVMsClient:        virtualMachineScaleSetVMsClient,
@@ -124,6 +131,13 @@ func newDeploymentsClient(authorizer autorest.Authorizer, subscriptionID, partne
 
 func newGroupsClient(authorizer autorest.Authorizer, subscriptionID, partnerID string) (*resources.GroupsClient, error) {
 	client := resources.NewGroupsClient(subscriptionID)
+	prepareClient(&client.Client, authorizer, partnerID)
+
+	return &client, nil
+}
+
+func newLoadBalancersClient(authorizer autorest.Authorizer, subscriptionID, partnerID string) (*network.LoadBalancersClient, error) {
+	client := network.NewLoadBalancersClient(subscriptionID)
 	prepareClient(&client.Client, authorizer, partnerID)
 
 	return &client, nil

--- a/service/collector/error.go
+++ b/service/collector/error.go
@@ -62,3 +62,22 @@ var missingOrganizationLabel = &microerror.Error{
 func IsMissingOrganizationLabel(err error) bool {
 	return microerror.Cause(err) == missingOrganizationLabel
 }
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	{
+		dErr, ok := c.(autorest.DetailedError)
+		if ok {
+			if dErr.StatusCode == 404 {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/service/collector/loadbalancer.go
+++ b/service/collector/loadbalancer.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/azure-collector/v2/service/credential"
+)
+
+var (
+	loadBalancerDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(MetricsNamespace, "load_balancer", "backend_pool_instances_count"),
+		"The number of instances behind a backend pool.",
+		[]string{
+			"cluster_id",
+			"load_balancer_name",
+			"backend_pool_name",
+		},
+		nil,
+	)
+)
+
+type LoadBalancerConfig struct {
+	G8sClient  versioned.Interface
+	K8sClient  kubernetes.Interface
+	Logger     micrologger.Logger
+	GSTenantID string
+}
+
+type LoadBalancer struct {
+	g8sClient  versioned.Interface
+	k8sClient  kubernetes.Interface
+	logger     micrologger.Logger
+	gsTenantID string
+}
+
+// NewLoadBalancer exposes metrics about the 'kubernetes' load balancer used to Kubernetes services with type LoadBalancer.
+func NewLoadBalancer(config LoadBalancerConfig) (*LoadBalancer, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.GSTenantID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GSTenantID must not be empty", config)
+	}
+
+	d := &LoadBalancer{
+		g8sClient:  config.G8sClient,
+		k8sClient:  config.K8sClient,
+		logger:     config.Logger,
+		gsTenantID: config.GSTenantID,
+	}
+
+	return d, nil
+}
+
+func (d *LoadBalancer) Collect(ch chan<- prometheus.Metric) error {
+	ctx := context.Background()
+	azureClientSets, err := credential.GetAzureClientSetsByCluster(ctx, d.k8sClient, d.g8sClient, d.gsTenantID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	lbNames := []string{"kubernetes", "kubernetes-internal"}
+
+	for clusterID, azureClientSet := range azureClientSets {
+		for _, lbName := range lbNames {
+			lb, err := azureClientSet.LoadBalancersClient.Get(context.Background(), clusterID, lbName, "")
+			if IsNotFound(err) {
+				// Load balancer might be missing, all good.
+				continue
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if lb.BackendAddressPools != nil {
+				for _, bp := range *lb.BackendAddressPools {
+					if bp.BackendIPConfigurations != nil {
+						ch <- prometheus.MustNewConstMetric(
+							loadBalancerDesc,
+							prometheus.GaugeValue,
+							float64(len(*bp.BackendIPConfigurations)),
+							clusterID,
+							lbName,
+							*bp.Name,
+						)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *LoadBalancer) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- loadBalancerDesc
+	return nil
+}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -78,6 +78,22 @@ func NewSet(config SetConfig) (*Set, error) {
 	}
 
 	{
+		c := LoadBalancerConfig{
+			G8sClient:  config.K8sClient.G8sClient(),
+			K8sClient:  config.K8sClient.K8sClient(),
+			Logger:     config.Logger,
+			GSTenantID: config.GSTenantID,
+		}
+
+		loadBalancerCollector, err := NewLoadBalancer(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		collectors = append(collectors, loadBalancerCollector)
+	}
+
+	{
 		c := ResourceGroupConfig{
 			K8sClient:  config.K8sClient.K8sClient(),
 			Logger:     config.Logger,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18746

This PR adds a new exporter, with the number of instances attached to the `kubernetes` and `kubernetes-internal` load balancers.