### PR TITLE
Fix: Increase CPU requests and limit to stabilize exporter

### DIFF
--- a/helm/azure-collector/templates/deployment.yaml
+++ b/helm/azure-collector/templates/deployment.yaml
@@ -75,8 +75,8 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: 100m
+            cpu: 200m
             memory: 100Mi
           limits:
-            cpu: 100m
+            cpu: 300m
             memory: 100Mi

--- a/helm/azure-collector/templates/vpa.yaml
+++ b/helm/azure-collector/templates/vpa.yaml
@@ -13,6 +13,8 @@ spec:
     - containerName: {{ .Chart.Name }}
       controlledValues: RequestsAndLimits
       mode: Auto
+      minAllowed:
+        cpu: 200m
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/22387

Exporter would stop scraping for certain periods of time. Suspected the issue were resource constraints. This PR bumps up the resource requests and limits.
